### PR TITLE
refactor: crawlingKeywordService와 crawlingTitleService에 html 문장 추출시 정확도 개선 및 응답 데이터에 urlAllText 추가

### DIFF
--- a/service/crawlingContentService.js
+++ b/service/crawlingContentService.js
@@ -34,7 +34,9 @@ const getCrawlingContentKeyword = async (req, res) => {
       }
     }
 
-    const urlText = getAllSentence(innerText).find((sentence) =>
+    const allSentence = getAllSentence(innerText);
+
+    const urlText = allSentence.find((sentence) =>
       sentence.toUpperCase().includes(upperCasedKeyword)
     );
 
@@ -45,6 +47,7 @@ const getCrawlingContentKeyword = async (req, res) => {
         hasKeyword: hasKeyword,
         urlTitle: title,
         urlText: urlText,
+        urlAllText: allSentence,
       });
     } else {
       return res.status(200).send({ message: `[This keyword does not exist]` });
@@ -76,16 +79,12 @@ const isCheckTrueThisUrl = (url) => {
 
 const getAllSentence = (innerText) => {
   return innerText
-    .replace(/\n|\r|\t/g, " ")
-    .split(/(?<=다\. |요\. |니다\. |\. |! |\? )/)
-    .reduce((array, sentence) => {
-      const trimedSentence = sentence.trim();
-
-      if (trimedSentence) {
-        array.push(trimedSentence);
-      }
-      return array;
-    }, []);
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(/(?<=[.?!])(?=\s)/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 0);
 };
 
 module.exports = { getCrawlingContentKeyword };

--- a/service/crawlingKeywordService.js
+++ b/service/crawlingKeywordService.js
@@ -13,8 +13,8 @@ const getCrawlingKeyword = async (req, res) => {
     let innerText = await page.evaluate(() => document.body.innerText);
     const upperCasedKeyword = keyword.toUpperCase();
     const hasKeyword = innerText.toUpperCase().includes(upperCasedKeyword);
-
-    const urlText = getAllSentence(innerText).find((sentence) =>
+    const allSentence = getAllSentence(innerText);
+    const urlText = allSentence.find((sentence) =>
       sentence.toUpperCase().includes(upperCasedKeyword)
     );
 
@@ -23,6 +23,7 @@ const getCrawlingKeyword = async (req, res) => {
         url: req.params.url,
         hasKeyword: hasKeyword,
         urlText: urlText,
+        urlAllText: allSentence,
       });
     } else if (!innerText) {
       await page.waitForSelector("iframe", { timeout: TIMEOUT });
@@ -41,8 +42,9 @@ const getCrawlingKeyword = async (req, res) => {
         .toUpperCase()
         .includes(upperCasedKeyword);
 
-      const urlText = getAllSentence(iframeInnerText).find((sentence) =>
-        sentence.includes(upperCasedKeyword)
+      const allSentence = getAllSentence(iframeInnerText);
+      const urlText = allSentence.find((sentence) =>
+        sentence.toUpperCase().includes(upperCasedKeyword)
       );
 
       if (!iframeUrl || !hasiframeUrlOfNaver) {
@@ -53,6 +55,7 @@ const getCrawlingKeyword = async (req, res) => {
           url: req.params.url,
           hasKeyword: hasKeywordOfIframe,
           urlText: urlText,
+          urlAllText: allSentence,
         });
       } else if (!hasKeywordOfIframe) {
         return res


### PR DESCRIPTION
### 어떤 PR유형인가요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 작업 내용을 요약해주세요

1. getAllSentence(innerText)를 중복 호출하지 않고, allSentence 를 활용하여 재사용하도록 리팩토링
2. replace(/[\r\n\t]+/g, " ")를 적용하여 개행 및 탭을 효율적으로 처리
3. 불필요한 공백을 줄이기 위해 .replace(/\s+/g, " ") 추가
